### PR TITLE
bugfix/fix typehint

### DIFF
--- a/src/Saml2/Auth.php
+++ b/src/Saml2/Auth.php
@@ -48,28 +48,28 @@ class Auth
     /**
      * NameID
      *
-     * @var string
+     * @var string|null
      */
     private $_nameid;
 
     /**
      * NameID Format
      *
-     * @var string
+     * @var string|null
      */
     private $_nameidFormat;
 
     /**
      * NameID NameQualifier
      *
-     * @var string
+     * @var string|null
      */
     private $_nameidNameQualifier;
 
     /**
      * NameID SP NameQualifier
      *
-     * @var string
+     * @var string|null
      */
     private $_nameidSPNameQualifier;
 
@@ -399,7 +399,7 @@ class Auth
     /**
      * Returns the nameID
      *
-     * @return string  The nameID of the assertion
+     * @return string|null  The nameID of the assertion
      */
     public function getNameId()
     {
@@ -409,7 +409,7 @@ class Auth
     /**
      * Returns the nameID Format
      *
-     * @return string  The nameID Format of the assertion
+     * @return string|null  The nameID Format of the assertion
      */
     public function getNameIdFormat()
     {
@@ -419,7 +419,7 @@ class Auth
     /**
      * Returns the nameID NameQualifier
      *
-     * @return string  The nameID NameQualifier of the assertion
+     * @return string|null  The nameID NameQualifier of the assertion
      */
     public function getNameIdNameQualifier()
     {
@@ -429,7 +429,7 @@ class Auth
     /**
      * Returns the nameID SP NameQualifier
      *
-     * @return string  The nameID SP NameQualifier of the assertion
+     * @return string|null  The nameID SP NameQualifier of the assertion
      */
     public function getNameIdSPNameQualifier()
     {


### PR DESCRIPTION
- update to new xmlseclibs with namespacing
- no more old saml
- Generate 3.0.0 branch for a future php-saml for php 7.X, namespaces and xmlseclibs loaded by composer
- Fix code style
- Make assertions compatible with PHP 7.2
- #237. Set RSA_SHA256 and SHA256 as default signatureAlgorithm and digestAlgorithm values
- Update test with the new sign algorithm behavior
- fix(composer): Exclude test files from Composer production downloads
- Remove compatibility.php file
- Restore php 5.4 dependency
- Clean code. Make compatible with php7.2 . Fix tests. Update travis to test php 7.2. Update dependencies in composer
- Add possibility to handle nameId NameQualifier attribute in SLO Request. Don't set unspecified NameIDFormat on LogoutRequest that conflicts on ADFS
- Add test for getNameIdNameQualifier
- Improvements to the code
- Use DateTime/DateTimeZone classes
- Improve phpdoc. Escape strings printed with debug enabled. Remove error_reporting
- Fixed issue with IdPMetadataParser only keeping 1 certificate when multiple certificates of a single type were provided. Add desiredSSOBinding and desiredSLOBinding to IdP Parser methods
- Document that SHA-1 must not be used
- Add more tests to cover IdPMetadataParser
- Update changelog and version
- Request now returns an exception instead of a string
- Rename methods, Add tests
- Adding test that checks VU-475445
- Improve how fingerprint is calcultated
- Add some fixes to xmlseclibs. Extra protection verifying the Signature algorithm used on SignedInfo element, not only rely on verify / verifySignature methods
- Add warning about the use of fingerprint on signature verification method
- .
- Add Namespaces
- Update travis
- Corrected psr-4 path for composer autoload
- Clean the composer.json file
- Use array typehints for array arguments
- Remove useless use statements
- Remove unused use statements in tests
- Fix phpdoc
- Remove dead code in the setting management
- Improve the readme
- Fix #286. Change Fatal Error to Exception on getID methods of LogoutRequest and LogoutResponse
- #269 Allow the getSPMetadata() method to always include the encryption KeyDescriptor
- Add FriendlyName support. New getAttributesWithFriendlyName method
- Support  and  parameters at getSPMetadata method
- New method of importing a decrypted assertion into the XML document to replace the EncryptedAssertion. Fix signature issues on Signed Encrypted Assertions with default namespace
- Add  parameter to the decryptElement method to make optional the formatting
- Fix typo
- Ability to pass protocol regex
- Include new xmlseclibs file on _toolkit_loader.php
- removed space after array constructor
- Fix componser autoloader at _toolkit_loader.php
- Refactor. Fix PHPDoc
- Another PHPDoc fix
- Fix typos
- Adjusted acs endpoint to extract NameQualifier and SPNameQualifier from SAMLResponse. Adjusted single logout service to provide NameQualifier and SPNameQualifier to logout method. Add getNameIdNameQualifier to Auth and SamlResponse. Extend logout method from Auth and LogoutRequest constructor to support SPNameQualifier parameter. Align LogoutRequest constructor with SAML specs"
- Release 3.0.0
- .
- Fix setting_example.php servicename parameter
- Remove unused var
- Security improvement suggested by Nils Engelbertz to prevent DDOS by expansion of internally defined entities (XEE)
- Release 3.1.0
- Update changelog with 3.1.0 info
- Fix doc of LogoutRequest getID method
- changes for 3.1
- test LogoutResponse to responseUrl
- add Idp setting ['singleLogoutService']['responseUrl']
- add more tests.
- read ResponseLocation from IdP metadata
- Force to use at least xmlseclibs 3.0.3 for security reasons
- Release 3.1.1
- Move the creation of the AuthnRequest object to separate function
- Set strict=true on config examples
- move phpunit.xml
- Add support for Subjects on AuthNRequests by the new parameter nameIdValueReq
- Typo on binding documentation
- Fix #344 Raise errors on IdPMetadataParser::parseRemoteXML and IdPMetadataParser::parseFileXML
- Fix #356. Support 'x509cert' and 'privateKey' on signMetadata security setting
- Release 3.2.0
- Fix #380
- Release 3.2.1
- Relax comparision of false on SignMetadata
- Fix typos on README
- Set true as the default value for strict setting
- Fix CI
- Release 3.3.0
- Fix phpunit
- Update xmlseclibs to 3.0.4
- Remove Comparison atribute from RequestedAuthnContext when setting has empty value
- Release 3.3.1
- Check destination against the getSelfURLNoQuery as well on LogoutRequest and LogoutResponse as we do on Response
- Improve getSelfRoutedURLNoQuery method
- At the IdPMetadataParser, Only add responseUrl to the settings if ResponseLocation present
- Ability to set custom schema path. Fix lib folder src/Saml2 instead src/. Use getSchemasPath on validateXML method
- Fix #395 Bad use of  on static method validateBinarySign
- Fix invalid error message when assertion and nameid was encrypted
- Add additional way to get the toolkit: git clone
- Support rejecting unsolicited SAMLResponses. Reject SAMLResponse if requestID was provided to the validotr but the InResponseTo attributeof the SAMLResponse is missing
- Update changelog
- Add setting for strict destination matching
- Release 3.4.0
- Add setSchemasPath to Auth class. Fix backward compatibility
- Release 3.4.1
- Fix unittest
- Check for x509Cert of the IdP when loading settings, even if the security index was not provided
- allowRepeatAttributeName settings added in order to support AttributeStatements with Attribute elements with the same name
- Fix #426 Get lib path dinamically
- Fix #443. Incorrect Destination in LogoutResponse when using responseUrl. Add IdP value getters to the Settings class
- Update xmlseclibs
- Sync commits from 2.X branch
- Update Changelog
- Release 3.5.1
- Mark the toolkit not PHP 8.0 ready
- 3.6.X dev branch
- Verify phpunit < 7.5.18 fixes Travis
- library working with php8
- min php version bumped, phpunit and phploc libs updated for versions compatible with php 8
- newer phpunit creates a file we can gitignore
- updated tests to be comatible with phpunit 9 depreciations
- Improve demo to print cause of Message invalidation if debug is enabled
- Add AES128_GCM encryption on generateNameId method. New setting parameter encryption_algorithm. If you set a encryption method different than AES128_CBC then the algorithm RSA_OAEP_MGF1P will be used as well instead RSA_1_5
- Prepare 4.X branch
- Force 7.3. Fix #457 phpunit issues
- Set travis for PHP 7.3, 7.4 and 8.0
- Move phpunit to require-dev
- Update dist on travis
- Fix phpcs
- Fix #467 bug on getSelfRoutedURLNoQuery method
- Adjust Travis and phpunit
- Release 4.0.0
- Fix the variable typehint, it may be null if validation failed
